### PR TITLE
Fix: updated makefile to docker compose V2 syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,42 +3,42 @@ VOLUME=$(shell basename $(PWD))
 develop: clean build migrations.upgrade run
 
 clean:
-	docker-compose rm -vf
+	docker compose rm -vf
 
 build:
-	docker-compose build
+	docker compose build
 
 run:
-	docker-compose up
+	docker compose up
 
 shell:
-	docker-compose run worker \
+	docker compose run worker \
 	  sh
 
 python-shell:
-	docker-compose run worker \
+	docker compose run worker \
 	  poetry run flask shell
 
 postgres.data.delete: clean
 	docker volume rm $(VOLUME)_postgres
 
 postgres.start:
-	docker-compose up -d postgres
-	docker-compose exec postgres \
+	docker compose up -d postgres
+	docker compose exec postgres \
 	  sh -c 'while ! nc -z postgres 5432; do sleep 0.1; done'
 
 migrations.blank: postgres.start
-	docker-compose run worker \
+	docker compose run worker \
 	  poetry run flask db revision
 
 migrations.create: postgres.start
-	docker-compose run worker \
+	docker compose run worker \
 	  poetry run flask db migrate
 
 migrations.upgrade: postgres.start
-	docker-compose run worker \
+	docker compose run worker \
 	  poetry run flask db upgrade
 
 migrations.heads: postgres.start
-	docker-compose run worker \
+	docker compose run worker \
 	  poetry run flask db heads


### PR DESCRIPTION
**Description**
Makefile failing due to referencing V1 docker compose
V1 no longer supported by [Docker](https://docs.docker.com/compose/migrate/)

Issue
Closes #12 